### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Jeferson Lima <jefersonlimaa@dcc.ufba.br>
 sentence=Translate Wiring and CPP language to your native language.
 paragraph=ArduinoLang is a library with headers which translate C++ and Wiring reserved words, to other languages different of english. To accomplish this, each header use macro in combination with some typedefs, those little tricks make the proccess of learn how to write code for Arduino easier.
 category=Communication
-url=jefersonla.github.io
+url=http://jefersonla.github.io
 architectures=avr


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.